### PR TITLE
[MSCMPUB-41] Add the ability to deploy into SCM sub-directory

### DIFF
--- a/src/main/java/org/apache/maven/plugins/scmpublish/AbstractScmPublishMojo.java
+++ b/src/main/java/org/apache/maven/plugins/scmpublish/AbstractScmPublishMojo.java
@@ -103,6 +103,13 @@ public abstract class AbstractScmPublishMojo
     protected File checkoutDirectory;
 
     /**
+     * Location where the content is published inside the <code>${checkoutDirectory}</code>.
+     * By default, content is copyed at the root of <code>${checkoutDirectory}</code>.
+     */
+    @Parameter ( property = "scmpublish.subDirectory" )
+    protected String subDirectory;
+
+    /**
      * Display list of added, deleted, and changed files, but do not do any actual SCM operations.
      */
     @Parameter ( property = "scmpublish.dryRun" )

--- a/src/main/java/org/apache/maven/plugins/scmpublish/ScmPublishPublishScmMojo.java
+++ b/src/main/java/org/apache/maven/plugins/scmpublish/ScmPublishPublishScmMojo.java
@@ -276,10 +276,34 @@ public class ScmPublishPublishScmMojo
 
         checkoutExisting();
 
+        final File updateDirectory;
+        if ( subDirectory == null )
+        {
+            updateDirectory = checkoutDirectory;
+        }
+        else
+        {
+            updateDirectory = new File( checkoutDirectory, subDirectory );
+
+            // Security check for subDirectory with .. inside
+            if ( !updateDirectory.toPath().normalize().startsWith( checkoutDirectory.toPath().normalize() ) )
+            {
+                logError( "Try to acces outside of the checkout directory with sub-directory: %s", subDirectory );
+                return;
+            }
+
+            if ( !updateDirectory.exists() )
+            {
+                updateDirectory.mkdirs();
+            }
+
+            logInfo( "Will copy content in sub-directory: %s", subDirectory );
+        }
+
         try
         {
             logInfo( "Updating checkout directory with actual content in %s", content );
-            update( checkoutDirectory, content, ( project == null ) ? null : project.getModel().getModules() );
+            update( updateDirectory, content, ( project == null ) ? null : project.getModel().getModules() );
             String displaySize = org.apache.commons.io.FileUtils.byteCountToDisplaySize( size );
             logInfo( "Content consists of " + MessageUtils.buffer().strong( "%d directories and %d files = %s" ),
                      directories, files, displaySize );


### PR DESCRIPTION
I just add a `subDirectory` path to the `checkoutDirectory` before launch the `update(...)` method.